### PR TITLE
Fix skelton FreemakerConfigurationProvider dependency to CLIModule

### DIFF
--- a/avans-setup/src/main/resources/archetype-resources/src/main/java/module/BasicModule.java
+++ b/avans-setup/src/main/resources/archetype-resources/src/main/java/module/BasicModule.java
@@ -4,12 +4,9 @@
 package ${package}.module;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
 
-import freemarker.template.Configuration;
 import ${package}.config.Config;
 import ${package}.provider.ConfigProvider;
-import ${package}.provider.web.FreemarkerConfigurationProvider;
 
 public class BasicModule extends AbstractModule {
 	private final Config config;
@@ -32,8 +29,5 @@ public class BasicModule extends AbstractModule {
 				.toProvider(ConfigProvider.class)
 				.asEagerSingleton();
 		}
-		bind(Configuration.class)
-			.toProvider(FreemarkerConfigurationProvider.class)
-			.in(Scopes.SINGLETON);
 	}
 }

--- a/avans-setup/src/main/resources/archetype-resources/src/main/java/module/WebModule.java
+++ b/avans-setup/src/main/resources/archetype-resources/src/main/java/module/WebModule.java
@@ -6,6 +6,10 @@ package ${package}.module;
 import javax.servlet.ServletContext;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+import freemarker.template.Configuration;
+import ${package}.provider.web.FreemarkerConfigurationProvider;
 
 import lombok.NonNull;
 
@@ -20,5 +24,8 @@ public class WebModule extends AbstractModule {
 	protected void configure() {
 		bind(ServletContext.class)
 				.toInstance(servletContext);
+		bind(Configuration.class)
+				.toProvider(FreemarkerConfigurationProvider.class)
+				.in(Scopes.SINGLETON);
 	}
 }

--- a/examples/sample/src/main/java/me/geso/sample/module/BasicModule.java
+++ b/examples/sample/src/main/java/me/geso/sample/module/BasicModule.java
@@ -1,12 +1,9 @@
 package me.geso.sample.module;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
 
-import freemarker.template.Configuration;
 import me.geso.sample.config.Config;
 import me.geso.sample.provider.ConfigProvider;
-import me.geso.sample.provider.web.FreemarkerConfigurationProvider;
 
 public class BasicModule extends AbstractModule {
 	private final Config config;
@@ -29,8 +26,5 @@ public class BasicModule extends AbstractModule {
 				.toProvider(ConfigProvider.class)
 				.asEagerSingleton();
 		}
-		bind(Configuration.class)
-			.toProvider(FreemarkerConfigurationProvider.class)
-			.in(Scopes.SINGLETON);
 	}
 }

--- a/examples/sample/src/main/java/me/geso/sample/module/WebModule.java
+++ b/examples/sample/src/main/java/me/geso/sample/module/WebModule.java
@@ -3,6 +3,10 @@ package me.geso.sample.module;
 import javax.servlet.ServletContext;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+import freemarker.template.Configuration;
+import me.geso.sample.provider.web.FreemarkerConfigurationProvider;
 
 import lombok.NonNull;
 
@@ -17,5 +21,8 @@ public class WebModule extends AbstractModule {
 	protected void configure() {
 		bind(ServletContext.class)
 				.toInstance(servletContext);
+		bind(Configuration.class)
+				.toProvider(FreemarkerConfigurationProvider.class)
+				.in(Scopes.SINGLETON);
 	}
 }


### PR DESCRIPTION
When create NewApp from archetype, CLI main method doesn't run because of following error. (and also test would fail.)

    Exception in thread "main" java.lang.NoClassDefFoundError: javax/servlet/ServletContext

This is because CLI need `BasicModule` which has configuration for `FreemakerConfigurationProvider`, it would be injected `ServletContext`.
But usually CLI doesn't use Servlet (is this true?), so I move `FreemakerConfigurationProvider`'s configuration from `BasicModule` into `WebModule`.