### PR TITLE
Convinient to deploy local application server without env setting for sample app.

### DIFF
--- a/examples/sample/src/main/java/me/geso/sample/provider/ConfigProvider.java
+++ b/examples/sample/src/main/java/me/geso/sample/provider/ConfigProvider.java
@@ -17,25 +17,25 @@ public class ConfigProvider implements Provider<Config> {
 	public Config get() {
 		String env = System.getProperty("sample.env");
 		if (env == null) {
-			throw new RuntimeException("Missing sample.env");
-		} else {
-			String fileName = "config/" + env + ".yml";
-			try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream(
-				fileName)) {
-				if (stream == null) {
-					throw new RuntimeException("Cannot load " + fileName
-						+ " from resource.");
-				}
-				try {
-					return new ObjectMapper(new YAMLFactory()).readValue(stream, Config.class);
-				} catch (JsonParseException | JsonMappingException e) {
-					throw new RuntimeException(String.format("Cannot parse %s: %s",
-						fileName, e.getMessage()));
-				}
-			} catch (IOException e) {
-				throw new RuntimeException(String.format("Cannot read %s from resources: %s",
+			//throw new RuntimeException("Missing sample.env");
+			env = "local";
+		} 
+		String fileName = "config/" + env + ".yml";
+		try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream(
+			fileName)) {
+			if (stream == null) {
+				throw new RuntimeException("Cannot load " + fileName
+					+ " from resource.");
+			}
+			try {
+				return new ObjectMapper(new YAMLFactory()).readValue(stream, Config.class);
+			} catch (JsonParseException | JsonMappingException e) {
+				throw new RuntimeException(String.format("Cannot parse %s: %s",
 					fileName, e.getMessage()));
 			}
+		} catch (IOException e) {
+			throw new RuntimeException(String.format("Cannot read %s from resources: %s",
+				fileName, e.getMessage()));
 		}
 	}
 }


### PR DESCRIPTION
In the case of sample app, when there is not a property named 'sample.env' in the environment, use 'local' instead for its value.
Because developing in NetBeans and deploying to Tomcat already configured, it does not have environmental value and need to set a option.