### PR TITLE
ObjectMapper was generated for each request

### DIFF
--- a/avans/src/main/java/me/geso/avans/ControllerBase.java
+++ b/avans/src/main/java/me/geso/avans/ControllerBase.java
@@ -95,9 +95,6 @@ public abstract class ControllerBase implements Controller,
 		this.setDefaultCharacterEncoding();
 
 		this.pathParams = Collections.unmodifiableMap(captured);
-
-		ObjectMapper objectMapper = createObjectMapper();
-		setObjectWriter(objectMapper.writer());
 	}
 
 	private void setDefaultCharacterEncoding() {

--- a/avans/src/main/java/me/geso/avans/jackson/JacksonJsonView.java
+++ b/avans/src/main/java/me/geso/avans/jackson/JacksonJsonView.java
@@ -14,7 +14,16 @@ public interface JacksonJsonView extends Controller, JSONRendererProvider {
 
 	class _PrivateStaticFields {
 		// only accessible in this interface.
-		private static ObjectWriter _writer = createObjectMapper().writer();
+		private static final ObjectMapper _defaultMapper;
+		private static ObjectMapper _mapper;
+		private static ObjectWriter _writer;
+
+		static {
+			ObjectMapper objectMapper = createObjectMapper();
+			_defaultMapper = objectMapper;
+			_mapper = objectMapper;
+			_writer = objectMapper.writer();
+		}
 
 		private static ObjectMapper createObjectMapper() {
 			ObjectMapper mapper = new ObjectMapper();
@@ -26,6 +35,13 @@ public interface JacksonJsonView extends Controller, JSONRendererProvider {
 
 	@Override
 	public default WebResponse renderJSON(final int statusCode, final Object obj) {
+		// If overrided createObjectMapper method, replace the writer only once
+		ObjectMapper objectMapper = createObjectMapper();
+		if (objectMapper != null && _PrivateStaticFields._mapper == _PrivateStaticFields._defaultMapper) {
+			_PrivateStaticFields._mapper = objectMapper;
+			_PrivateStaticFields._writer = objectMapper.writer();
+		}
+
 		byte[] json;
 		try {
 			json = _PrivateStaticFields._writer.writeValueAsBytes(obj);
@@ -51,13 +67,6 @@ public interface JacksonJsonView extends Controller, JSONRendererProvider {
 	}
 
 	public default ObjectMapper createObjectMapper() {
-		return _PrivateStaticFields.createObjectMapper();
-	}
-
-	/**
-	 * called by me.geso.avans.ControllerBase#init
-	 */
-	public default void setObjectWriter(ObjectWriter writer) {
-		_PrivateStaticFields._writer = writer;
+		return null;
 	}
 }

--- a/avans/src/main/java/me/geso/avans/jackson/JacksonJsonView.java
+++ b/avans/src/main/java/me/geso/avans/jackson/JacksonJsonView.java
@@ -37,7 +37,8 @@ public interface JacksonJsonView extends Controller, JSONRendererProvider {
 	public default WebResponse renderJSON(final int statusCode, final Object obj) {
 		// If overrided createObjectMapper method, replace the writer only once
 		ObjectMapper objectMapper = createObjectMapper();
-		if (objectMapper != null && _PrivateStaticFields._mapper == _PrivateStaticFields._defaultMapper) {
+		if (objectMapper != _PrivateStaticFields._defaultMapper &&
+			_PrivateStaticFields._mapper == _PrivateStaticFields._defaultMapper) {
 			_PrivateStaticFields._mapper = objectMapper;
 			_PrivateStaticFields._writer = objectMapper.writer();
 		}
@@ -67,6 +68,6 @@ public interface JacksonJsonView extends Controller, JSONRendererProvider {
 	}
 
 	public default ObjectMapper createObjectMapper() {
-		return null;
+		return _PrivateStaticFields._defaultMapper;
 	}
 }

--- a/avans/src/test/java/me/geso/avans/jackson/JacksonJsonViewTest.java
+++ b/avans/src/test/java/me/geso/avans/jackson/JacksonJsonViewTest.java
@@ -754,15 +754,19 @@ public class JacksonJsonViewTest {
             ControllerBase sut = new ControllerBase() {};
             sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
             sut.renderJSON(new HashMap<>());
+            sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
+            sut.renderJSON(new HashMap<>());
 
-            // The ObjectWriter is default?
+            // Is the default ObjectWriter?
             ObjectWriter writer = (ObjectWriter) filed.get(privateStaticFields);
             JsonFactory factory = writer.getFactory();
             boolean actual = factory.isEnabled(JsonGenerator.Feature.ESCAPE_NON_ASCII);
             assertThat(actual, is(true));
 
-            // Same ObjectWriter after re-construct the instance?
+            // Is the same instance after re-construct?
             sut = new ControllerBase() {};
+            sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
+            sut.renderJSON(new HashMap<>());
             sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
             sut.renderJSON(new HashMap<>());
             ObjectWriter newWriter = (ObjectWriter) filed.get(privateStaticFields);
@@ -774,15 +778,19 @@ public class JacksonJsonViewTest {
             ControllerMock sut = new ControllerMock();
             sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
             sut.renderJSON(new HashMap<>());
+            sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
+            sut.renderJSON(new HashMap<>());
 
-            // The ObjectWriter was Overrided?
+            // Was the ObjectWriter Overrided?
             ObjectWriter writer = (ObjectWriter) filed.get(privateStaticFields);
             JsonFactory factory = writer.getFactory();
             boolean isEnabled = factory.isEnabled(JsonGenerator.Feature.ESCAPE_NON_ASCII);
             assertThat(isEnabled, is(false));
 
-            // Same ObjectWriter after re-construct the instance?
+            // Is the same instance after re-construct?
             sut = new ControllerMock();
+            sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
+            sut.renderJSON(new HashMap<>());
             sut.init(new HttpServletRequestMock(), new HttpServletResponseMock(), new HashMap<>());
             sut.renderJSON(new HashMap<>());
             ObjectWriter newWriter = (ObjectWriter) filed.get(privateStaticFields);


### PR DESCRIPTION
I didn't have enough consideration in #58
ObjectMapper was generated for each request.

This p-r will break backwards compatibility

- Delete JacksonJsonView#setObjectWriter
  - It breaks backwards compatibility from 2.4.0, but don't break from 2.3.0
  - This method was added in [#58](https://github.com/tokuhirom/avans/pull/58/files#diff-f23b7e47576c4bae7c8ebe029fc6ef0cR60)


# jmh benchmark result

## before

[log file](https://gist.github.com/matsumana/f2a55485a70170112decb56a63ddd6b7#file-8_before_2e5e315-txt)

```
Benchmark                               Mode  Cnt   Score   Error  Units
JacksonJsonParamReaderBenchmark.bench  thrpt   10   3.754 ± 0.921  ops/s
JacksonJsonViewBenchmark.bench         thrpt   10  66.371 ± 5.291  ops/s
```

## after

[log file](https://gist.github.com/matsumana/f2a55485a70170112decb56a63ddd6b7#file-9_after_2e5e315-txt)

```
Benchmark                               Mode  Cnt   Score   Error  Units
JacksonJsonParamReaderBenchmark.bench  thrpt   10   6.719 ± 2.546  ops/s
JacksonJsonViewBenchmark.bench         thrpt   10  67.605 ± 4.022  ops/s
```
